### PR TITLE
docs(handoffs): refresh cascade-c for post-Sprint-1 operating surface

### DIFF
--- a/docs/handoffs/cascade-c-obsidian.md
+++ b/docs/handoffs/cascade-c-obsidian.md
@@ -11,7 +11,7 @@ You are a fresh Cascade picking up the meta-system's knowledge-integration verti
 
 You wire up the Obsidian MCP so Cascade-A authored skills can read and (where appropriate) write to the user's personal knowledge vault. Goal: cross-project notes (research log, thesis notes, paper summaries, brainstorm spillover) become first-class citizens of the system — `@grill-me`, `/recalibrate`, `@to-prd` can all reach into Obsidian for context.
 
-You do **not** modify L1 (`~/.windsurf/`) outside of adding the Obsidian-aware MCP wiring + (if absolutely necessary) one or two new rules / skill updates that touch Obsidian-specific behavior. Even those are first proposed via the queue → Cascade A's `@update-horizontal` route, **not** authored directly by you.
+You do **not** author L1 directly. The L1 active surface per ADR-014 is `~/.codeium/windsurf/` (skills / global_workflows / memories/global_rules.md) plus `~/.windsurf/` (contracts / templates) — neither is yours to edit. Per ADR-017, every L1 proposal (new rule, skill edit, workflow edit, template change, AGENTS.md edit) routes through `@propose-extension`, which dispatches to `@write-skill` / `@update-horizontal` / direct-write per its route table. Your touchpoint on L1 is authoring well-shaped proposals; horizontal Cascade A approves and applies them via `@sprint-review` → `@update-horizontal`.
 
 You are vertical, not horizontal. Stay in scope.
 
@@ -19,16 +19,19 @@ You are vertical, not horizontal. Stay in scope.
 
 | # | Path | Why |
 |---|---|---|
-| 1 | `~/Projects/cascade-system/README.md` | Top-level orientation |
-| 2 | `~/Projects/cascade-system/docs/structure.md` | Meta-repo conventions |
-| 3 | `~/Projects/cascade-system/retros/sprint-1.md` | What just shipped + open observations |
-| 4 | `~/Projects/cascade-system/docs/decisions/INDEX.md` | All ADRs |
-| 5 | `~/.windsurf/contracts/phase-taxonomy.md` | Note `obsidian://` artifact path scheme is reserved (M1.3 §4) |
-| 6 | `~/Projects/cascade-system/docs/rules/*.md` | All L1 rules (you operate under these) |
-| 7 | `~/.codeium/windsurf/skills/grill-me/SKILL.md` | Reads context from Obsidian when enabled (M1.2 §1) |
-| 8 | `~/.codeium/windsurf/skills/to-prd/SKILL.md` | Reads linked vault notes (M1.6) |
-| 9 | `~/.codeium/windsurf/global_workflows/recalibrate.md` | Future drift signal: vault notes vs PRD |
-| 10 | The user's Obsidian vault path (ask the user; not hardcoded) | Your operating surface |
+| 1 | `~/Projects/cascade-system/AGENTS.md` | Auto-loaded on workspace open; start-here orientation + invocation cheat-sheet pointer (added post-Sprint-1) |
+| 2 | `~/Projects/cascade-system/docs/manual.md` | **All sections** — especially "Mental model", "Spawning a vertical Cascade", "Release discipline", "Invocation cheat-sheet" (authored post-Sprint-1 per ADR-018 Phase B) |
+| 3 | `~/Projects/cascade-system/README.md` | Top-level orientation |
+| 4 | `~/Projects/cascade-system/retros/sprint-1.md` | What shipped in Sprint 1 + open observations |
+| 5 | `~/Projects/cascade-system/docs/decisions/INDEX.md` | All ADRs — pay attention to ADR-014 (L1 canonical paths), ADR-015 (`@` vs `/` syntax), ADR-016 (workflow path correction), **ADR-017** (`@propose-extension` — your mandatory L1-proposal channel), **ADR-018** (`@release-manager` — your mandatory main-bound-commit channel) |
+| 6 | `~/.windsurf/contracts/phase-taxonomy.md` | `obsidian://` artifact path scheme is reserved (M1.3 §4) |
+| 7 | `~/Projects/cascade-system/docs/rules/*.md` | Long-form L1 rule archive (you operate under the concise versions in `global_rules.md`; read archive for rationale) |
+| 8 | `~/.codeium/windsurf/skills/grill-me/SKILL.md` | Reads context from Obsidian when enabled (M1.2 §1) |
+| 9 | `~/.codeium/windsurf/skills/to-prd/SKILL.md` | Reads linked vault notes (M1.6) |
+| 10 | `~/.codeium/windsurf/global_workflows/recalibrate.md` | Future drift signal: vault notes vs PRD |
+| 11 | `~/Projects/cascade-system/queue/pending-review.md` | Open learning queue; read-only (drain is `@sprint-review`'s job, not yours) |
+| 12 | `~/.codeium/windsurf/mcp_config.json` | `obsidian-mcp-server` is pre-registered but `disabled: true` — M2C.1 evaluates and enables (or swaps for a better MCP) |
+| 13 | The user's Obsidian vault path (ask the user; not hardcoded) | Your operating surface |
 
 ## 3 — Work to do (Sprint 2 Vertical C)
 
@@ -52,18 +55,19 @@ Per plan §4 Sprint 2:
 
 - **M2C.6** — Write the vertical retro at `~/Projects/cascade-system/retros/sprint-2-vertical-c.md`. Cover what shipped, vault layout decisions, MCP choice rationale, friction.
 
-Each milestone closes its corresponding GitHub issue (filed during Sprint 0 M0.6 — check Project board for the M2C.x issues).
+Each milestone needs a GitHub issue. **Sprint 0 M0.6 only filed Sprint 1 (M1.x) issues — M2C.x issues do NOT exist yet.** Your first real action (before executing M2C.1) is to open `M2C.1` through `M2C.6` as issues on `ReebalSami/cascade-system` and attach them to the `cascade-system roadmap` Project. Per ADR-001 routing: issue creation via `mcp3_issue_write` (method `create`); milestone creation + project-attachment via `gh` CLI with `GITHUB_TOKEN= GH_TOKEN=` prefix.
 
 ## 4 — Operating constraints
 
 You operate under all L1 rules in `~/Projects/cascade-system/docs/rules/`. Highlights for your work:
 
-- **`adapt-from-all`**: research the Obsidian MCP space (HuggingFace, GitHub, awesome-mcp lists) before building anything custom. Cite consultation in any ADR.
-- **`document-as-you-go`**: ADR for MCP selection, ADR for vault layout convention, ADR for any rule additions.
-- **L1 changes go through the queue** → Cascade A's `@update-horizontal`. You write proposals; you don't apply L1 directly. Even small additions like `obsidian-context-priming` rule must route via Cascade A or the next horizontal `@sprint-review`.
+- **`adapt-from-all`**: research the Obsidian MCP space (HuggingFace `mcp4_space_search`, GitHub search, awesome-mcp lists) before building anything custom. Cite consultation in any ADR's `sources_consulted`.
+- **`document-as-you-go`**: ADR for MCP selection, ADR for vault layout convention, ADR for any rule additions. Reserve NNN in `INDEX.md` before authoring (per ADR-009).
+- **`@propose-extension` is the single intake channel for ALL L1 proposals** (per ADR-017). Invoke it for every rule / skill-edit / workflow-edit / contract / template / `AGENTS.md` change you want to propose. Do NOT author L1 artifacts directly; `@propose-extension` dispatches to the right path (`@write-skill` / `@update-horizontal` / direct-write) and enforces the `adapt-from-all` + 3-test gate. Horizontal Cascade A's next `@sprint-review` decides promotion.
+- **`@release-manager` is mandatory for every main-bound commit** (per ADR-018). Use `/branch-start <type>/obsidian-<slug>` for each unit of work. Helper workflows: `/commit` for commits with body content, `/branch-push-and-pr` for PR open, `/ci-watch` (will report "no CI configured; merge gate is manual review only" — that's fine, exit clean), `/branch-merge-and-cleanup` for squash-merge + cleanup. The `branch-and-pr-required` rule is always-on; never `git push origin main` directly outside cold-start.
 - **`no-time-estimates`**, **`no-quantity-over-shape`**, **`no-terminal-oneline-scripts`**, **`make-sure-it-works`**, **`be-honest-direct-critical`** all apply.
-- **Privacy**: the user's vault contains personal notes. Read carefully; don't dump unrelated notes into PRDs or chat. Surface only what's directly relevant to the active project.
-- **`bidirectional-learning-pipe`**: capture every cross-project insight (those are the whole point of this vertical) to the queue.
+- **Privacy**: the user's vault contains personal notes. Read carefully with `grep_search` / `find_by_name` to locate intent; don't dump unrelated notes into PRDs or chat. Surface only what's directly relevant to the active project.
+- **`bidirectional-learning-pipe`**: capture every cross-project insight (those are the whole point of this vertical) to `cascade-system/queue/pending-review.md` with date + project + cascade tags.
 
 ADR routing per ADR-001 still applies for any GitHub mutations you do (issue close + comment via MCP; project mutations via `gh`).
 


### PR DESCRIPTION
Keeps `docs/handoffs/cascade-c-obsidian.md` self-contained (per its own line-8 claim) after ADRs 014–018 closed. Four targeted edits to a single file; zero scope changes to M2C.1–M2C.6 milestones.

## Drift fixed

| Section | Drift | Fix |
|---|---|---|
| §1 Your role (line 14) | Referenced `~/.windsurf/` as "L1" (pre-migration path) | Updated to ADR-014 split: `~/.codeium/windsurf/` for active surface; `~/.windsurf/` for contracts + templates. Replaced queue → `@update-horizontal` route with `@propose-extension` per ADR-017. |
| §2 Read-list (10 → 13 rows) | Missing AGENTS.md + manual.md; no callout for post-Sprint-1 ADRs; missing queue + mcp_config pointers | Added AGENTS.md at row 1; manual.md at row 2 with explicit new-section callouts (Mental model / Spawning a vertical Cascade / Release discipline / Invocation cheat-sheet); enriched INDEX.md row with ADR-014/015/016/017/018 names; added queue row + mcp_config row. |
| §4 Operating constraints | No mention of `@propose-extension` or `@release-manager` mandates | Added two mandatory-channel bullets citing ADR-017 and ADR-018 with helper-workflow list. |
| §3 closing paragraph | Claimed M2C.x issues *"filed during Sprint 0 M0.6"* — FALSE; Sprint 0 filed only Sprint 1 issues | Corrected: issues don't exist yet; made creation Cascade C's explicit first action; named ADR-001 MCP-vs-gh routing. |

## Preserved verbatim (Sprint 1 historical voice)

Header authorship + sprint/plan-ref lines, §1 opening paragraph, §3 milestone bodies (the scope itself), §5 Useful starting points, §6 Pitfalls, §7 Definition of done, §8 Termination + handoff, §9 Provenance.

## Why now

User is about to spawn Cascade C from the kickoff prompt at `~/.windsurf/plans/cascade-c-obsidian-kickoff-4fa159.md`. That prompt currently patches the drift externally (its "Known drift in the handoff doc" section). Fixing the handoff doc itself:

- Lets the kickoff prompt simplify post-merge
- Ensures anyone who reads `docs/handoffs/cascade-c-obsidian.md` directly (without the kickoff prompt) gets current state, not Sprint-1 state
- Honors the doc's own line-8 claim of being self-contained

## Release-discipline compliance

This PR is the **second** end-to-end exercise of the ADR-018 cluster (first was PR #14). Same flow: `/branch-start` → `/commit` (tempfile-based body) → `/branch-push-and-pr` (this step) → `/ci-watch` (expected no-CI exit) → `/branch-merge-and-cleanup` (user 4-option gate).

## Test plan

- [x] Single file changed — `git show --stat 68bdd5e` confirms
- [x] Edits preserve table structure + markdown rendering (visual inspection)
- [x] §3 M2C.1–M2C.6 milestone bodies byte-identical to main
- [ ] `/ci-watch` reports no-CI exit cleanly
- [ ] Post-merge: simplify `~/.windsurf/plans/cascade-c-obsidian-kickoff-4fa159.md` by removing the "Known drift in the handoff doc" section (unversioned file; separate edit outside this PR)

## Refs

- ADR-014 (L1 canonical paths) · ADR-017 (`@propose-extension`) · ADR-018 (`@release-manager`)
- `retros/sprint-1.md` (Sprint 1 close context)
- `queue/pending-review.md` (read-only; not drained in this PR)
- Kickoff prompt: `~/.windsurf/plans/cascade-c-obsidian-kickoff-4fa159.md` (will be simplified post-merge)
