### PR TITLE
docs(1.5.3): author docs/cheat-sheet.md + manual.md pointer

### DIFF
--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -1,0 +1,144 @@
+# Cascade-system cheat-sheet
+
+Single-page scannable inventory. Goal: a fresh reader (or future-you) answers *"what skills/workflows/rules exist and what does each do?"* in under 60 seconds.
+
+**Companion docs**
+
+- `docs/manual.md` — narrative (mental model, lifecycle, release discipline)
+- `docs/architecture/system-overview.mmd` — single-diagram view of how the layers + skills + workflows + rules connect
+- `docs/skills/INDEX.md` and `docs/workflows/INDEX.md` — pointer indexes (machine-maintained by `@docs-refresh`)
+- `docs/rules/INDEX.md` — long-form rule archive
+
+**Authoritative paths** (per ADR-014):
+
+- Active L1 surface: `~/.codeium/windsurf/skills/<name>/SKILL.md`, `~/.codeium/windsurf/global_workflows/<name>.md`, `~/.codeium/windsurf/memories/global_rules.md`
+- L1 contracts + templates: `~/.windsurf/contracts/`, `~/.windsurf/templates/`
+- L2 workspace overlays: `<project>/.windsurf/{rules,skills,workflows}/`
+- Plan files: `~/.windsurf/plans/<slug>-<suffix>.md`
+
+---
+
+## 1 — Skills (11)
+
+`@<skill-name>` — auto-activated by description match. Per ADR-015, skills are stateful, judgment-heavy, multi-step.
+
+| Skill | Purpose | Phase / when |
+|---|---|---|
+| `@grill-me` | Socratic interview that walks the design tree until shared understanding | brainstorm phase, plan stress-tests, "too many implicit assumptions" |
+| `@to-prd` | Convert approved brainstorm artifact → PRD using shared template | spec phase |
+| `@to-issues` | Decompose PRD §11 vertical slices → GitHub issues + milestones + Project cards | issues phase |
+| `@sync-github` | Reconcile Project board with repo signals; flag naked commits; idempotent | board has drifted; before `@sprint-review` |
+| `@sprint-review` | Heartbeat retro: drain queue, write retro, propose L1 promotions, hand off to `@update-horizontal` | milestone close |
+| `@update-horizontal` | Apply L1 change (rule/skill/workflow/contract/template); writes change ADR; propagates downstream | invoked by `@sprint-review` after L1 promotion |
+| `@verify-l1` | Validate L1 storage layout against ADR-014; check rule cap; flag drift | read-only audit, idempotent |
+| `@docs-refresh` | Validate + regenerate `docs/` placement; regenerate INDEX files; audit diagrams | after ADR/handoff/retro changes |
+| `@release-manager` | Orchestrate branch lifecycle: branch → commits → push → PR → CI → squash-merge → cleanup | every `main`-bound change |
+| `@propose-extension` | **Single intake channel** for any system extension; 5-question interview, route table | "I want to add a new rule/skill/workflow" |
+| `@write-skill` | Author/edit a skill body (frontmatter, structure, sources_consulted) | invoked by `@propose-extension` for skill routes |
+
+Canonical paths: `~/.codeium/windsurf/skills/<name>/SKILL.md`. Maintained index: `docs/skills/INDEX.md`.
+
+---
+
+## 2 — Workflows (9)
+
+`/<workflow-name>` — slash-only, no auto-activation. Per ADR-015, workflows are deterministic procedures.
+
+| Workflow | Purpose |
+|---|---|
+| `/start-project` | Bootstrap new project from L3 template (15 steps): scaffold + repo + Project + milestones + first-phase handoff |
+| `/run-phase <name>` | Dispatcher — reads `<project>/.windsurf/phases.yaml` and invokes the named phase's skill (no arg = list phases with status) |
+| `/recalibrate` | Detect/resolve drift between PRD §11, GitHub state, recent commits; per-finding triage |
+| `/add-project-type` | Bootstrap new L3 template at `~/.windsurf/templates/<type>/` (12 steps + ADR) |
+| `/branch-start` | (helper for `@release-manager`) — start branch or worktree |
+| `/branch-push-and-pr` | (helper) — push + `gh pr create --fill` |
+| `/ci-watch` | (helper) — watch PR's CI status with adaptive cadence; clean exit when no CI configured |
+| `/branch-merge-and-cleanup` | (helper) — squash-merge + delete branch + sync `main` |
+| `/commit` | Safe multi-paragraph git commit (tempfile + `git commit -F`); bypasses macOS-Windsurf newline crash (per ADR-013) |
+
+Canonical paths: `~/.codeium/windsurf/global_workflows/<name>.md`. Maintained index: `docs/workflows/INDEX.md`.
+
+---
+
+## 3 — Rules (17)
+
+**16 always-on** in `~/.codeium/windsurf/memories/global_rules.md` (single file, ≤6000 char cap, no per-rule frontmatter).
+
+| Group | Rules |
+|---|---|
+| **Path / storage discipline** | `l1-canonical-paths`, `clean-project-structure` |
+| **Shell safety** | `no-terminal-oneline-scripts` |
+| **Git / release discipline** | `branch-and-pr-required` |
+| **Tone / honesty** | `be-honest-direct-critical`, `anti-laziness-core-principles` |
+| **Reasoning quality** | `no-half-knowledge`, `make-sure-it-works`, `context7-and-docs-first` |
+| **Documentation** | `document-as-you-go`, `adapt-from-all` |
+| **Plan / lifecycle hygiene** | `no-quantity-over-shape`, `no-time-estimates`, `bidirectional-learning-pipe`, `plan-drift-watcher`, `sprint-review-prompt` |
+
+**1 workspace-only** at `<project>/.windsurf/rules/know-your-hardware.md` (deployed by `/start-project` step 6a; trigger: `model_decision`):
+
+- `know-your-hardware` — alerts on resource-heavy intent; AWS escalation requires explicit user approval with budget surfaced
+
+Long-form archive: `docs/rules/<name>.md`. Index: `docs/rules/INDEX.md`.
+
+---
+
+## 4 — Contracts (1)
+
+| Contract | Purpose | Path |
+|---|---|---|
+| `phase-taxonomy` | Schema for L3 templates' `phases.yaml` files (consumed by `/run-phase`, `/recalibrate`, `@sprint-review`, `plan-drift-watcher`) | `~/.windsurf/contracts/phase-taxonomy.md` |
+
+---
+
+## 5 — L3 templates
+
+| Template | Status | Purpose |
+|---|---|---|
+| `_shared/` | active | universal `docs/` structure + INDEX files + `strict-docs-placement` rule (applied first by `/start-project` two-pass scaffold per ADR-004) |
+| `python-ml-uv` | active | Pattern A — Python ML / research (uv + PyTorch + Jupyter); used by Master-Thesis vertical |
+| `nextjs-app` | not built yet | Pattern B — TypeScript full-stack; defer until first project demands it |
+| `python-pipeline` | not built yet | Pattern D — data pipeline; defer until first project demands it |
+
+Templates live at `~/.windsurf/templates/<type>/` with `phases.yaml` + `scaffold/` + optional `rules/` + `skills/` + `workflows/` overlays.
+
+---
+
+## 6 — How to extend the system
+
+**Single intake channel: `@propose-extension`** (per ADR-017). It interviews you with 5 questions (build vs capture, artifact type, layer, problem, activation/trigger), runs an `adapt-from-all` consultation pass, decides whether an ADR is needed, presents a route + (optional) ADR draft for your approval, then dispatches.
+
+| Artifact you want to add or modify | `@propose-extension` route |
+|---|---|
+| New skill (any layer) | invokes `@write-skill` |
+| New rule (any layer) | direct authoring (L1 dual: long-form archive + concise `global_rules.md`; L2/L3: workspace/template path) |
+| New workflow (any layer) | direct authoring at canonical path |
+| New contract (L1) | direct authoring at `~/.windsurf/contracts/<name>.md` |
+| New L3 project type | invokes `/add-project-type` |
+| Modify existing L1 artifact | invokes `@update-horizontal` |
+| New shared scaffold asset | direct authoring at `~/.windsurf/templates/_shared/<path>` |
+| AGENTS.md (any workspace root) | direct authoring at `<project>/AGENTS.md` |
+| Capture-only (defer build) | append to `cascade-system/queue/pending-review.md` |
+
+**Never** author L1 artifacts under `~/.windsurf/skills/`, `~/.windsurf/workflows/`, or `~/.windsurf/rules/` — those paths are dead per ADR-014 and Windsurf does not scan them.
+
+---
+
+## 7 — How to start work
+
+| You want to … | Invoke | What it does |
+|---|---|---|
+| Start a project from a new idea or brainstorm note | `@begin` | Reads the idea note, runs `@grill-me`, decides L3 stack, dispatches to `/add-project-type` (if needed) → `/start-project` → `/run-phase brainstorm` |
+| Pick up a vertical Cascade from a handoff doc | `@kickoff` | Reads handoff + parent plan + cited ADRs + cheat-sheet, determines lifecycle position, files vertical's milestone issues if missing, asks ONE focused starting question |
+| Resume work in an existing project | open the project directory | `AGENTS.md` auto-loads + L2 rules auto-load; ask *"what's in flight?"* or invoke `/run-phase` (no arg) to list phases with artifact status |
+| Land a change to `main` | `@release-manager` | Orchestrates branch → commits → push → PR → CI → squash-merge → cleanup (delegates to 4 helper workflows) |
+| Close a sprint milestone | `@sprint-review` | Drains queue, writes retro, decides L1 promotions, hands off to `@update-horizontal` |
+
+---
+
+## Cross-references
+
+- `docs/manual.md` — narrative manual (mental model, "where things live", lifecycle, release discipline). When the cheat-sheet says *what*, the manual says *why*.
+- `docs/decisions/INDEX.md` — all ADRs (ADR-014/015/016/017/018 are the highest-leverage reads for this cheat-sheet)
+- `docs/architecture/system-overview.mmd` — diagram view
+- `cascade-system/AGENTS.md` — the always-on first-touch pointer for fresh Cascades reading this repo
+- `~/.windsurf/plans/<slug>-<suffix>.md` — sprint plans (live outside this repo)

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -2,6 +2,8 @@
 
 The day-to-day operating guide for the Cascade lifecycle system. Covers what lives where, how to make changes safely, and how to start new work. Authoritative for "where" questions; refer to ADRs for "why" questions.
 
+> **Looking for a scannable inventory?** See `docs/cheat-sheet.md` for the one-page list of every skill, workflow, rule, contract, and template, plus how to start work (`@begin` / `@kickoff`) and how to extend the system (`@propose-extension`). The cheat-sheet says *what*; this manual says *why*.
+
 ## Where things live
 
 The L1 layer (global rules, skills, workflows, contracts, templates) is split across two roots because Windsurf only scans one of them and global rules have a hard size cap. Per ADR-014:


### PR DESCRIPTION
Sprint 1.5.3 — close the discoverability gap surfaced by the
audit (closed PRs #14/#15/#16 had no scannable inventory of
skills/workflows/rules; manual.md is 231 lines covering 7
topics, too heterogeneous to scan).

Adds:

- `docs/cheat-sheet.md` (new) — one-page inventory:
  - §1 Skills (11) — name, purpose, phase/when (matches
    canonical L1 paths per ADR-014)
  - §2 Workflows (9) — name, purpose
  - §3 Rules (17) — grouped by purpose; 16 always-on +
    1 workspace-only `know-your-hardware` per ADR-018
  - §4 Contracts (1) — phase-taxonomy with consumers listed
  - §5 L3 templates — _shared + python-ml-uv active;
    nextjs-app + python-pipeline deferred (just-in-time per
    plan §5)
  - §6 How to extend — `@propose-extension` route table
    (per ADR-017)
  - §7 How to start work — `@begin` (new ideas) /
    `@kickoff` (vertical pickup) / open-dir resume /
    `@release-manager` for `main`-bound changes /
    `@sprint-review` for milestone close
  - Cross-references to manual, ADR INDEX, system-overview
    diagram (1.5.5), AGENTS.md

- `docs/manual.md` (edit) — top-of-file blockquote pointer
  to the new cheat-sheet, framed as "cheat-sheet says
  *what*; manual says *why*". Single-line addition; no
  other manual content touched (1.5.10 will decide whether
  to split or de-duplicate manual after the cheat-sheet has
  matured).

Acceptance criteria (plan §3 1.5.3):

- [x] File exists at canonical path
- [x] All 11 skills, 9 workflows, 17 rules, 1 contract,
      current templates listed
- [x] Tables render correctly in GitHub markdown preview
- [x] manual.md adds top-of-file pointer
- [ ] AGENTS.md adds cross-reference (handled by 1.5.8)
- [ ] PR merged

Forward-references:

- `@begin` and `@kickoff` are referenced as canonical
  start-work entry points but ship in 1.5.1 + 1.5.2 (later
  in this sprint). Until those land, the cheat-sheet's §7
  forward-references will resolve to "skill not found".
  This is acceptable per ADR-005's precedent (skills
  named in plan/ADR before authoring; `@release-manager`
  was named in ADR-018 before its SKILL.md existed).
- `docs/architecture/system-overview.mmd` is referenced
  but ships in 1.5.5.
- `docs/skills/INDEX.md` and `docs/workflows/INDEX.md` are
  referenced but ship in 1.5.4.

Sprint 1.5 — Onboard Ramp:

- Issue: closes #23 (Sprint 1.5.3)
- Milestone: #1 (Sprint 1.5 — Onboard Ramp)
- Plan: `~/.windsurf/plans/sprint-1-5-onboard-ramp-f8add2.md` §3 1.5.3

Refs:

- ADR-014 (L1 canonical storage paths) — paths cited
- ADR-015 (`@` skills vs `/` workflows) — invocation table
- ADR-017 (`@propose-extension` intake channel) — §6
- ADR-018 (release-discipline cluster) — `know-your-hardware`
  workspace-only deployment
- Plan §2 D4 (cheat-sheet location decision)
