### PR TITLE
chore(handoff): scrub thesis pollution + §9 guardrails + M2B.8

### DIFF
--- a/docs/handoffs/cascade-b-template-python-ml-uv.md
+++ b/docs/handoffs/cascade-b-template-python-ml-uv.md
@@ -7,7 +7,7 @@
 
 You are a fresh Cascade picking up the meta-system's first L3 template authoring. Sprint 1 (L1 Foundation) is complete; this handoff is **self-contained** — disk + GitHub state are the only inputs you need.
 
-> **Note on amendment (added pre-vertical-B kickoff)**: Vertical B was queued at end-of-Sprint-1 but bypassed in favor of Vertical C / C2 (Obsidian work). When `@kickoff` opened this handoff, Sprint 1.5 + Vertical C + Vertical C2 had shipped, adding ADRs 014–031, the cheat-sheet / manual / system-overview-diagram, the `@begin` / `@kickoff` / `@verify-l1` / `@vault-research` / `@vault-distill` / `@release-manager` / `@propose-extension` skills, the `/commit` and `/branch-*` workflows, and L1 storage canonicalization (ADR-014). This handoff has been **amended in place** (per ADR-011 supersession-over-deletion: original semantics preserved; gaps filled): §2 read-list extended, §4 constraints extended with post-Sprint-1.5 idioms, §3 M2B.3 + M2B.4 annotated with modern uv + adapt-from-all guidance, §3 milestone-filing note corrected. Substantive scope (M2B.1 → M2B.7 work breakdown) is unchanged. The "self-contained" claim above remains true *for the disk + GitHub state at amendment time* — but the read-list (§2) is the authoritative orientation, and reading only the original Sprint-1-era pointers would skip post-Sprint-1.5 system surface that Vertical B operates against. Amendment plan: `~/.windsurf/plans/cascade-b-kickoff-6bbb3c.md`.
+> **Note on amendment (added pre-vertical-B kickoff)**: Vertical B was queued at end-of-Sprint-1 but bypassed in favor of Vertical C / C2 (Obsidian work). When `@kickoff` opened this handoff, Sprint 1.5 + Vertical C + Vertical C2 had shipped, adding ADRs 014–031, the cheat-sheet / manual / system-overview-diagram, the `@begin` / `@kickoff` / `@verify-l1` / `@vault-research` / `@vault-distill` / `@release-manager` / `@propose-extension` skills, the `/commit` and `/branch-*` workflows, and L1 storage canonicalization (ADR-014). This handoff has been **amended in place** (per ADR-011 supersession-over-deletion: original semantics preserved; gaps filled): §2 read-list extended, §4 constraints extended with post-Sprint-1.5 idioms, §3 M2B.3 + M2B.4 annotated with modern uv + adapt-from-all guidance, §3 milestone-filing note corrected. Substantive scope (M2B.1 → M2B.7 work breakdown) is unchanged. The "self-contained" claim above remains true *for the disk + GitHub state at amendment time* — but the read-list (§2) is the authoritative orientation, and reading only the original Sprint-1-era pointers would skip post-Sprint-1.5 system surface that Vertical B operates against. Amendment was authored in a separate planning Cascade; the planning artifact is preserved per ADR-011 supersession-over-deletion but is **not** load-bearing for this vertical — the handoff itself is the canonical orientation.
 
 ## 1 — Your role
 
@@ -15,7 +15,7 @@ You author the `python-ml-uv` L3 project-type template at `~/.windsurf/templates
 
 You do **not** modify L1 (`~/.windsurf/`). If a gap is found in L1 during your work, log it via `bidirectional-learning-pipe` to `~/Projects/cascade-system/queue/pending-review.md` for Sprint 2's `@sprint-review` to triage.
 
-You are vertical, not horizontal. Stay in scope.
+You are vertical, not horizontal. Stay in scope. **Read §9 (Scope guardrails) before any work** — it explicitly enumerates what B is NOT.
 
 ## 2 — Read these in order before doing anything
 
@@ -74,7 +74,7 @@ Per plan §4 Sprint 2:
 
   **Amendment note for M2B.4**: per `adapt-from-all`, before authoring each skill, consult the vendored references at `refs/superpowers/`, `refs/mattpocock-skills/`, `refs/claude-skills/`, `refs/awesome-agent-skills/`. Specifically:
   - For `@tdd`: `refs/superpowers/skills/test-driven-development/` is the canonical adapt-from source (red → green → refactor with pytest).
-  - For `@literature-review`: no clear upstream; synthesize from research-discipline patterns + (optionally) the user's own thesis context via `@vault-research` (vault has 26 thesis hits as of amendment time).
+  - For `@literature-review`: no clear upstream; synthesize from generic research-discipline patterns (literature search, paper triage, summarization, citation hygiene). Skill must be domain-agnostic — Cascade D's thesis project will customize at consumption time, not B's template at authoring time.
   - For `@run-experiment`: consult `refs/` for any experiment-runner skill; else synthesize from notebook-discipline + reproducibility primitives.
   - Each authored skill carries `sources_consulted` + `adapted_for` frontmatter per ADR-006 schema. Each skill's authoring lands as a separate PR via `@release-manager`.
 
@@ -83,6 +83,17 @@ Per plan §4 Sprint 2:
 - **M2B.6** — Validate the template via `/start-project --dry-run python-ml-uv-test python-ml-uv`. Fix until clean.
 
 - **M2B.7** — Write a vertical retro at `~/Projects/cascade-system/retros/sprint-2-vertical-b.md` (note: this retro is per-vertical, not per-sprint, since both verticals B and C are in Sprint 2). Format per `~/.windsurf/templates/_shared/retro-template.md`.
+
+- **M2B.8** — Author Cascade-D handoff doc at `cascade-system/docs/handoffs/cascade-d-master-thesis.md` (slug placeholder; final slug + thesis-name decided by user at D's kickoff). Models on this handoff's precedent (`cascade-b-template-python-ml-uv.md`). Required sections:
+  - §1 Mission for Cascade D — bootstrap thesis project from `python-ml-uv` via `/start-project <thesis-name> python-ml-uv`, then run `/run-phase brainstorm`
+  - §2 Read-list — this B-handoff is the precedent shape; cite the shipped `python-ml-uv` artifacts + ADR-014 path conventions
+  - §3 Work-breakdown placeholder — D defines its M2D.x milestones in its own `@grill-me` brainstorm; this handoff does NOT pre-decompose D's work
+  - §4 Operating constraints — all L1 rules apply; `@release-manager` for `main`-bound changes
+  - §5 First action — fresh Cascade D's `@kickoff` step 7 question is *"thesis name + slug?"*, then dispatch to `/start-project`
+  - §6 Termination — D writes its own per-vertical retro at `cascade-system/retros/sprint-N-vertical-d.md`
+  - §7 Provenance — cites this B-handoff as the precedent + cites M2B.8 closure as the issuing milestone
+
+  Do **not** pre-load thesis-domain content (no §203/ZUGFeRD/GraphRAG references); the handoff orients D, it does not author thesis-specific framing. Land via `@release-manager` (single PR).
 
 Each milestone closes its corresponding GitHub issue. **Note (amendment)**: Sprint 0 M0.6 did not actually file the M2B.x issues — Vertical C went first, then C2; B was bypassed. The 7 M2B.x issues + milestones are filed at vertical-start by `@kickoff` step 6 (see amendment note above). Check the Project board after the kickoff dispatch to confirm.
 
@@ -106,7 +117,7 @@ Post-Sprint-1.5 idioms (added at amendment time):
 - **`/commit` (ADR-013)**: for any commit with multi-paragraph message body. Single-line `git commit -m "subject"` is OK for subject-only commits. Embedded newlines in `-m` arguments WILL CRASH the macOS-Windsurf integrated terminal (rule `no-terminal-oneline-scripts`).
 - **`@propose-extension` (ADR-017)**: if you observe an L1 gap that warrants a build (rather than just capture), do NOT author L1 directly — route via `@propose-extension` which dispatches to `@write-skill` / `@update-horizontal` / direct-write per artifact type. Capture-only friction still goes to `bidirectional-learning-pipe` queue per the bullet above.
 - **`@verify-l1` (ADR-029)**: after authoring template artifacts, run `@verify-l1` to validate L1 layout against ADR-014 + path-drift sweep. Catches dead `~/.windsurf/skills/` / `~/.windsurf/workflows/` / `~/.windsurf/rules/` references in template files.
-- **`@vault-research` (ADR-024)**: when authoring skills that benefit from user-vault context (e.g., `@literature-review` for the thesis-domain corpus), use `@vault-research`. Vault has 26 thesis hits + 10 ML hits as of amendment time; thesis-precursor courses (DL, GNN, Safe RL) are in `originals/academic/masters/courses/`. Use `obsidian` CLI per ADR-022 (filesystem-direct reads on iCloud-symlinked vault hit ghost-empty failures).
+- **`@vault-research` (ADR-024)**: available as an L1 skill if any authored template skill genuinely benefits from user-vault context. Use only for **capability-discovery** (what kinds of patterns the user might want surfaced), never for **prescriptive content** (what the skill outputs at runtime). Use `obsidian` CLI per ADR-022 (filesystem-direct reads on iCloud-symlinked vault hit ghost-empty failures).
 
 ADR routing per ADR-001:
 - Issue close + comment → MCP (`mcp3_add_issue_comment` + `mcp3_issue_write`)
@@ -137,6 +148,7 @@ You're finished when:
 
 - All M2B.x issues are closed (verify in Project board)
 - The template is validated via `/start-project --dry-run`
+- M2B.8 — Cascade-D handoff exists at `cascade-system/docs/handoffs/cascade-d-master-thesis.md` and passes its own §1–§7 self-check
 - Sprint 2 vertical B retro is written and `Status: closed`
 - Any L1 observations are in `~/Projects/cascade-system/queue/pending-review.md`
 - Final commit pushed to the cascade-system repo with a clean working tree
@@ -145,11 +157,24 @@ You're finished when:
 
 When done, your last action is:
 
-> Vertical B (`python-ml-uv` L3 template) complete. Retro at `retros/sprint-2-vertical-b.md`. Cascade D (thesis) can now run `/start-project <thesis-name> python-ml-uv` to bootstrap from this template. L1 observations queued for Cascade A's next horizontal `@sprint-review`.
+> Vertical B (`python-ml-uv` L3 template) complete. Retro at `retros/sprint-2-vertical-b.md`. Cascade-D handoff at `cascade-system/docs/handoffs/cascade-d-master-thesis.md`. Cascade D (thesis) can now run `@kickoff cascade-system/docs/handoffs/cascade-d-master-thesis.md` in a fresh Cascade window. L1 observations queued for Cascade A's next horizontal `@sprint-review`.
 
 Do **not** start Cascade D's work yourself. That's a separate vertical with its own handoff.
 
-## 9 — Provenance
+## 9 — Scope guardrails: what B is NOT
+
+Vertical B authors a **generic** Python ML / research template. Specifically:
+
+- **Not thesis-specific.** The user has a Master's thesis project queued for Cascade D, but B's template MUST be domain-agnostic. ANY future ML project — tabular Kaggle, RL agent training, vision research, NLP fine-tuning, GNN, LLM evaluation harness, etc. — should be able to bootstrap from `python-ml-uv`.
+- **Don't read `/Users/reebal/Projects/FH-Wedel/SS26/Master-Thesis/`.** That directory holds an abandoned thesis-prep iteration. Cascade D will start fresh at `/Users/reebal/Projects/<thesis-name>/` via `/start-project <thesis-name> python-ml-uv`. There is no POC migration. Reading that directory will mislead the brainstorm phase into encoding thesis-specific patterns.
+- **No domain-specific content** in the template, scaffold, skills, or rules. Forbidden examples: §203 StGB / Steuerberater workflow, ZUGFeRD / XRechnung, document VLMs (Granite-Docling, olmOCR-2, etc.), GraphRAG, Bilanzbuchhalter, EN 16931, knowledge-graph schemas. These are Cascade D's concerns at the project level, not B's at the template level.
+- **`@vault-research` for capability discovery only.** If any L3 skill genuinely benefits from user-vault context, surface PATTERNS (e.g., "users often want a citation-hygiene check") not CONTENTS (e.g., specific paper titles, specific course notes).
+
+**Acceptance test** — would `python-ml-uv` be useful as-is to bootstrap an unrelated ML project that has nothing to do with documents/KGs/§203 (e.g., a tabular Kaggle baseline, an LLM eval harness, a basic vision classifier)? If no → the template is too thesis-specific; reframe.
+
+This section supersedes any contradictory wording elsewhere in this handoff (§1's "including the upcoming thesis project, Cascade D" is a *consumer note*, not a content prescription — Cascade D's needs do not shape B's content; B's generic surface enables D's needs alongside other consumers).
+
+## 10 — Provenance
 
 This handoff is the sprint-1-to-sprint-2 vertical-spawn for Vertical B. Pattern derived from `cascade-system/docs/decisions/ADR-002-handoff-prompts-subdirectory.md` and `cascade-a-sprint-1.md` (the precedent handoff).
 


### PR DESCRIPTION
Cluster A — Scrub thesis-domain tilt that survived PR #74 in
docs/handoffs/cascade-b-template-python-ml-uv.md:
- Line 10: drop kickoff-plan pointer (legacy plan has thesis pollution)
- Line 77: @literature-review amendment — replace "thesis context via
  @vault-research (vault has 26 thesis hits)" with domain-agnostic
  generic research-discipline framing
- Line 109: @vault-research operating-constraint — replace
  "thesis-domain corpus" wording with capability-discovery-only
  discipline (no prescriptive content from vault)

Cluster B — Add new §9 "Scope guardrails: what B is NOT":
- Explicit "not thesis-specific" framing; ANY future ML project
  (tabular Kaggle / RL / vision / NLP / GNN / LLM eval) should
  bootstrap from python-ml-uv
- Explicit "Don't read /Users/reebal/Projects/FH-Wedel/SS26/
  Master-Thesis/" rule — no POC migration, fresh start at
  /Users/reebal/Projects/<thesis-name>/ for Cascade D
- Forbidden domain examples enumerated: §203 StGB, ZUGFeRD,
  document VLMs, GraphRAG, Bilanzbuchhalter, EN 16931, KG schemas
- Acceptance test for template generality
- Supersession clause over §1 consumer-note language
- Provenance section renumbered §9 → §10
- §1 forward-reference callout: "Read §9 before any work"

Cluster C — Add M2B.8 "Author Cascade-D handoff doc" milestone:
- §3 entry with the 7 required sections for the D-handoff at
  cascade-system/docs/handoffs/cascade-d-master-thesis.md
- Explicit "do not pre-load thesis-domain content" guardrail
- §7 DoD bullet added
- §8 termination message updated — references D-handoff path,
  instructs Cascade D to @kickoff against it in fresh window
- GitHub milestone + covering issue + Project #5 entry filed
  via post-merge GitHub mutations (per ADR-001 routing)

Cluster D — Soft-deprecate legacy kickoff plan
~/.windsurf/plans/cascade-b-kickoff-6bbb3c.md (outside this repo;
not in this PR) with top-line "DEPRECATED for fresh-Cascade pickup"
note. Preserved per ADR-011 supersession-over-deletion; explicitly
not load-bearing for fresh Cascade B.

Net effect: fresh Cascade B can @kickoff against the canonical
handoff and orient cleanly with explicit anti-pollution discipline.

Plan: ~/.windsurf/plans/cascade-b-fresh-cascade-prep-6bbb3c.md
Refs: PR #74 (prior amendment); issues #75 + #78 body updates
deferred to post-merge GitHub mutations.
