### PR TITLE
feat(M2B.5): notebook-discipline + uv-discipline L3 rules

### DIFF
--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -97,7 +97,7 @@ Long-form archive: `docs/rules/<name>.md`. Index: `docs/rules/INDEX.md`.
 | Template | Status | Purpose |
 |---|---|---|
 | `_shared/` | active | universal `docs/` structure + INDEX files + `strict-docs-placement` rule (applied first by `/start-project` two-pass scaffold per ADR-004) |
-| `python-ml-uv` | in progress (Vertical B; M2B.1–M2B.4 shipped — awaits M2B.5–M2B.6) | Pattern A — Python ML / research (uv + jupytext + papermill + mypy + ruff + pytest; tracker-agnostic; stdlib seeding); will be consumed by Master-Thesis vertical (Cascade D) once M2B.6 validates |
+| `python-ml-uv` | in progress (Vertical B; M2B.1–M2B.5 shipped — awaits M2B.6 validation) | Pattern A — Python ML / research (uv + jupytext + papermill + mypy + ruff + pytest; tracker-agnostic; stdlib seeding; `notebook-discipline` + `uv-discipline` L3 rules); will be consumed by Master-Thesis vertical (Cascade D) once M2B.6 validates |
 | `nextjs-app` | not built yet | Pattern B — TypeScript full-stack; defer until first project demands it |
 | `python-pipeline` | not built yet | Pattern D — data pipeline; defer until first project demands it |
 


### PR DESCRIPTION
## Summary

Authors two L3 workspace rules at `~/.windsurf/templates/python-ml-uv/rules/` per M2B.1 brainstorm B7=A. Deployed to consumer projects via `/start-project` step 6b.

- **`notebook-discipline.md`** (75 lines) — codifies B2=A: experiments in `experiments/` as jupytext-paired `.py:percent` only; `.ipynb` is transient build artifact; Cascade-authored content is `.py` only (agent-side `.ipynb`-brittleness clause)
- **`uv-discipline.md`** (120 lines) — three clauses: (a) no `pip install` → `uv add`; (b) no bare `python script.py` → `uv run python script.py`; (c) no mixed package managers (poetry / pipx / conda / pip-tools / pyenv shell forbidden). Renamed from handoff §3 candidate `use-uv-not-pip` per brainstorm carry-forward line 294
- Both: `trigger: model_decision`, full ADR-006 frontmatter, explicit activation-trigger keyword lists + when-NOT-fires sections, fire / not-fire examples
- Issue #79 body updated at M2B.5 start to reflect the rename + broader scope (per brainstorm carry-forward line 294)

## Changes

- `docs/cheat-sheet.md` line 100 — `python-ml-uv` status updated to `in progress (Vertical B; M2B.1–M2B.5 shipped — awaits M2B.6 validation)`; tooling list expanded with the two new rules
- `~/.windsurf/templates/python-ml-uv/rules/notebook-discipline.md` (disk; outside repo per L1 storage gap)
- `~/.windsurf/templates/python-ml-uv/rules/uv-discipline.md` (disk; outside repo)

## Single-PR bundling (M2B.4 pattern)

Both rules in one PR — same rationale as M2B.4 (L3 artifacts live outside the cascade-system repo). Already-queued L1 friction entry "M2B.4 single-PR bundling deviation from handoff §3" covers the pattern; M2B.5 is the second data point reinforcing it.

## Adapt-from-all

`notebook-discipline`: brainstorm B2=A (own) + jupytext docs (browsed) + papermill docs (browsed) + `no-half-knowledge` rule (own) for the brittleness clause.

`uv-discipline`: brainstorm B7=A (own, with rename per line 294) + uv docs via `context7 /astral-sh/uv` (browsed) + `no-terminal-oneline-scripts` (own) + `no-half-knowledge` (own).

## Refs

- Spec: `docs/prompts/stages/02-brainstorm-python-ml-uv.md` (B7=A carry-forward lines 162 + 294)
- Plan: `~/.windsurf/plans/cascade-project-system-cac5f9.md` §4 Sprint 2 Vertical B
- Handoff: `docs/handoffs/cascade-b-template-python-ml-uv.md`
- ADRs: ADR-006 (frontmatter schema), ADR-014 (L3 rule paths), ADR-018 (`model_decision` trigger pattern)

Closes #79

## Test plan

- [x] Both rules carry valid workspace-rule frontmatter (`trigger: model_decision` + `description`); pattern matches `know-your-hardware` precedent
- [x] Activation-trigger keyword lists are concrete (avoid over-activation)
- [x] No domain-specific framing (handoff §9 acceptance test passes)
- [ ] Rules fire correctly when consumer hits matching keywords — verifiable empirically only after `/start-project --dry-run` deploys them (M2B.6) + first consumer use
